### PR TITLE
Fixes BCCs not working ever in many SMTP sending scenarios

### DIFF
--- a/email.go
+++ b/email.go
@@ -112,6 +112,9 @@ func (e *Email) msgHeaders() textproto.MIMEHeader {
 	if _, ok := res["Cc"]; !ok && len(e.Cc) > 0 {
 		res.Set("Cc", strings.Join(e.Cc, ", "))
 	}
+	if _, ok := res["Bcc"]; !ok && len(e.Bcc) > 0 {
+		res.Set("Bcc", strings.Join(e.Bcc, ", "))
+	}
 	if _, ok := res["Subject"]; !ok && e.Subject != "" {
 		res.Set("Subject", e.Subject)
 	}


### PR DESCRIPTION
Rackspace, Gmail, Gmail oAuth etc, BCCs were never working.

Not sure if there is a reason we ommitted BCCs from the raw email but I can't seem to think of one or find one.

Task: https://digitalcrew.teamwork.com/app/tasks/24762824